### PR TITLE
fix: use script event api and fix issues with chunking

### DIFF
--- a/src/Communication.ts
+++ b/src/Communication.ts
@@ -1,4 +1,4 @@
-import { DimensionTypes, world } from '@minecraft/server';
+import { system } from '@minecraft/server';
 
 interface Message {
   id: string;
@@ -20,8 +20,6 @@ export const buildServerNamespace = (namespace: string) => `${MINESCRIPTERS_NAME
 
 export const inputMessageEvent = (namespace: string) => `${buildServerNamespace(namespace)}:rmi.event-payload`;
 
-export const sendEvent = (event: string) => {
-  DimensionTypes.getAll().some((dt) => {
-    return world.getDimension(dt.typeId)?.runCommand(`scriptevent ${event}`).successCount;
-  });
+export const sendEvent = (event: string, message: string) => {
+  system.sendScriptEvent(event, message);
 };

--- a/src/Schema.test.ts
+++ b/src/Schema.test.ts
@@ -279,6 +279,28 @@ describe('Schema', () => {
     ).not.toThrow();
   });
 
+  it('one or other', () => {
+    const schema: SchemaEntry = [
+      SchemaEntryType.STRING,
+      SchemaEntryType.BOOL, // string | boolean
+    ];
+
+    expect(() => validate(schema, 'hello world')).not.toThrow();
+    expect(() => validate(schema, 'other string')).not.toThrow();
+    expect(() => validate(schema, true)).not.toThrow();
+    expect(() => validate(schema, false)).not.toThrow();
+
+    const aggregateError = new AggregateError(
+      ['Invalid schema, not a string', 'Invalid schema, not a bool'],
+      'Invalid schema, none of the schemas matched'
+    );
+
+    expect(() => validate(schema, 1)).toThrow(aggregateError);
+    expect(() => validate(schema, 1.5)).toThrow(aggregateError);
+    expect(() => validate(schema, undefined)).toThrow(aggregateError);
+    expect(() => validate(schema, null)).toThrow();
+  });
+
   it('complex objects', () => {
     const schema: SchemaEntry = {
       type: SchemaEntryType.OBJECT,

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -74,18 +74,19 @@ export const validate = (schema: SchemaEntry, obj: unknown) => {
 
   if (Array.isArray(schema)) {
     let passed = false;
+    const errors = [];
     for (const subSchema of schema) {
       try {
         validate(subSchema, obj);
         passed = true;
         break;
       } catch (e) {
-        console.error(e);
+        errors.push(e);
       }
     }
 
     if (!passed) {
-      throw new Error('Invalid schema');
+      throw new AggregateError(errors, 'Invalid schema, none of the schemas matched');
     }
     return;
   }

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -94,7 +94,7 @@ const start = (server: Server) => {
 };
 
 export const stopServer = (server: Server) => {
-  sendEvent(serverStopEvent(server));
+  sendEvent(serverStopEvent(server), '');
 };
 
 export const startServer = (_server: Server) => {


### PR DESCRIPTION
## Summary by Sourcery

Switch message transport to use the Minecraft script event API directly and correct message chunking logic for large payloads.

New Features:
- Support sending and receiving RMI payloads larger than the script event size limit via corrected chunking.

Bug Fixes:
- Fix chunk slicing loop so data is correctly split based on the message length instead of a constant.
- Remove chunk padding and associated parsing issues that interfered with script event payload handling.
- Ensure schema validation over union types reports all underlying errors via AggregateError instead of a generic error.

Enhancements:
- Replace command-based script event invocation with direct system.sendScriptEvent usage.
- Simplify test mocks to align with the new script event API and cover long-input and union-schema validation scenarios.

Tests:
- Add collaboration test covering endpoint invocation with very long input to verify chunking and reassembly.
- Add schema test for union types that expects an AggregateError when none of the alternatives match.